### PR TITLE
Made cc65 detect a possibly missing argument at the end of a function…

### DIFF
--- a/src/cc65/expr.c
+++ b/src/cc65/expr.c
@@ -1,7 +1,7 @@
 /* expr.c
 **
 ** 1998-06-21, Ullrich von Bassewitz
-** 2017-12-05, Greg King
+** 2020-01-25, Greg King
 */
 
 
@@ -278,9 +278,9 @@ static void WarnConstCompareResult (void)
 
 
 static unsigned FunctionParamList (FuncDesc* Func, int IsFastcall)
-/* Parse a function parameter list and pass the parameters to the called
-** function. Depending on several criteria this may be done by just pushing
-** each parameter separately, or creating the parameter frame once and then
+/* Parse a function parameter list, and pass the parameters to the called
+** function. Depending on several criteria, this may be done by just pushing
+** each parameter separately, or creating the parameter frame once, and then
 ** storing into this frame.
 ** The function returns the size of the parameters pushed.
 */
@@ -322,7 +322,7 @@ static unsigned FunctionParamList (FuncDesc* Func, int IsFastcall)
 
         /* Do we have more than one parameter in the frame? */
         if (FrameParams > 1) {
-            /* Okeydokey, setup the frame */
+            /* Okeydokey, set up the frame */
             FrameOffs = StackPtr;
             g_space (FrameSize);
             StackPtr -= FrameSize;
@@ -343,7 +343,7 @@ static unsigned FunctionParamList (FuncDesc* Func, int IsFastcall)
         /* Fetch the pointer to the next argument, check for too many args */
         if (ParamCount <= Func->ParamCount) {
             /* Beware: If there are parameters with identical names, they
-            ** cannot go into the same symbol table, which means that in this
+            ** cannot go into the same symbol table, which means that, in this
             ** case of errorneous input, the number of nodes in the symbol
             ** table and ParamCount are NOT equal. We have to handle this case
             ** below to avoid segmentation violations. Since we know that this
@@ -364,7 +364,7 @@ static unsigned FunctionParamList (FuncDesc* Func, int IsFastcall)
                 /* End of param list reached, no ellipsis */
                 Error ("Too many arguments in function call");
             }
-            /* Assume an ellipsis even in case of errors to avoid an error
+            /* Assume an ellipsis even in case of errors, to avoid an error
             ** message for each other argument.
             */
             Ellipsis = 1;
@@ -373,7 +373,7 @@ static unsigned FunctionParamList (FuncDesc* Func, int IsFastcall)
         /* Evaluate the parameter expression */
         hie1 (&Expr);
 
-        /* If we don't have an argument spec, accept anything, otherwise
+        /* If we don't have an argument spec., accept anything; otherwise,
         ** convert the actual argument to the type needed.
         */
         Flags = CF_NONE;
@@ -433,6 +433,12 @@ static unsigned FunctionParamList (FuncDesc* Func, int IsFastcall)
             break;
         }
         NextToken ();
+
+        /* Check for stray comma */
+        if (CurTok.Tok == TOK_RPAREN) {
+            Error ("Argument expected after comma");
+            break;
+        }
     }
 
     /* Check if we had enough parameters */
@@ -441,11 +447,11 @@ static unsigned FunctionParamList (FuncDesc* Func, int IsFastcall)
     }
 
     /* The function returns the size of all parameters pushed onto the stack.
-    ** However, if there are parameters missing (which is an error and was
-    ** flagged by the compiler) AND a stack frame was preallocated above,
-    ** we would loose track of the stackpointer and generate an internal error
+    ** However, if there are parameters missing (which is an error, and was
+    ** flagged by the compiler), AND a stack frame was preallocated above,
+    ** we would loose track of the stackpointer, and generate an internal error
     ** later. So we correct the value by the parameters that should have been
-    ** pushed to avoid an internal compiler error. Since an error was
+    ** pushed, to avoid an internal compiler error. Since an error was
     ** generated before, no code will be output anyway.
     */
     return ParamSize + FrameSize;


### PR DESCRIPTION
… argument list.

(It could be a stray comma at the end of the list.)