### PR TITLE
Fixed an error message printer.

### DIFF
--- a/src/da65/labels.c
+++ b/src/da65/labels.c
@@ -97,7 +97,9 @@ static void AddLabel (unsigned Addr, attr_t Attr, const char* Name)
              strcmp (SymTab[Addr], Name) == 0))) {
             return;
         }
-        Error ("Duplicate label for address $%04X: %s/%s", Addr, SymTab[Addr], Name);
+        Error ("Duplicate label for address $%04X (%s): '%s'", Addr,
+               SymTab[Addr] == 0 ? "<unnamed label>" : SymTab[Addr],
+               Name == 0 ? "<unnamed label>" : Name);
     }
 
     /* Create a new label (xstrdup will return NULL if input NULL) */


### PR DESCRIPTION
The disassembler can be built and won't crash if it sees duplicate labels, and one of them is an unnamed label.