### PR TITLE
PMG_SIZE_QUAD is 3, not 2.

### DIFF
--- a/include/_gtia.h
+++ b/include/_gtia.h
@@ -95,7 +95,7 @@ struct __gtia_write {
 
 #define PMG_SIZE_NORMAL 0x0 /* one color clock per pixel */
 #define PMG_SIZE_DOUBLE 0x1 /* two color clocks per pixel */
-#define PMG_SIZE_QUAD   0x2 /* four color clocks per pixel */
+#define PMG_SIZE_QUAD   0x3 /* four color clocks per pixel */
 
 
 /* COLPM0-COLPM3, COLPF0-COLPF3, COLBK color registers */


### PR DESCRIPTION
From "Mapping the Atari": "Size of player. POKE with zero or two for normal size (eight color clocks wide), POKE with one to double a player's width (sixteen color clocks wide), and POKE with three for quadruple width (32 color clocks wide). Each player can have its own width set."