### PR TITLE
Rebase

### DIFF
--- a/asminc/apple2.inc
+++ b/asminc/apple2.inc
@@ -15,6 +15,7 @@ PROMPT  :=      $33     ; Used by GETLN
 RNDL    :=      $4E     ; Random counter low
 RNDH    :=      $4F     ; Random counter high
 HIMEM   :=      $73     ; Highest available memory address+1
+CURLIN  :=      $75     ; Current line number being executed
 
 ;-----------------------------------------------------------------------------
 ; Vectors

--- a/libsrc/apple2/read.s
+++ b/libsrc/apple2/read.s
@@ -19,11 +19,14 @@
         .segment        "ONCE"
 
 initprompt:
-        ; Set prompt <> ']' to let DOS 3.3 know that we're
-        ; not in Applesoft immediate mode and thus keep it
-        ; from scanning our device I/O for DOS commands.
+        ; Set prompt <> ']' and currently executed Applesoft
+        ; line number hibyte <> $FF to let DOS 3.3 (at $A65E)
+        ; know that we're not in Applesoft immediate mode and
+        ; thus keep it from scanning our device I/O for DOS
+        ; commands.
         lda     #$80            ; Same value used at $D52C
         sta     PROMPT
+        sta     CURLIN+1        ; Any value <> $FF will do
         rts
 
         .code


### PR DESCRIPTION
Certain scenarios (e.g. not running any Applesoft program at all since booting DOS 3.3) can make DOS 3.3 consider cc65 device input (e.g. getchar()) that reads a CR interpreting the command in the keyboard buffer. Setting the hibyte of the Applesoft currently executed line number to some value <> $FF (beside setting the input prompt to some value <> ']') makes DOS 3.3 understand that we're not in intermediate mode and that therefore I/O not preceded with ctrl-d mustn't be fiddled with (see DOS 3.3 routine at $A65E).