### PR TITLE
atarixl configs: RAM memory area was renamed to MAIN in d8c31cf1d3b72…

### DIFF
--- a/cfg/atarixl-largehimem.cfg
+++ b/cfg/atarixl-largehimem.cfg
@@ -54,7 +54,7 @@ SEGMENTS {
     SYSCHKTRL:   load = SYSCHKTRL,                    type = ro,                optional = yes;
 
     SRPREPHDR:   load = SRPREPHDR,                    type = ro;
-    LOWBSS:      load = SRPREPCHNK,                   type = bss, define = yes;  # shared btw. SRPREPCHNK and RAM, not zero initialized
+    LOWBSS:      load = SRPREPCHNK,                   type = bss, define = yes;  # shared btw. SRPREPCHNK and MAIN, not zero initialized
     SRPREP:      load = SRPREPCHNK,                   type = rw,  define = yes;
     SHADOW_RAM:  load = SRPREPCHNK, run = HIDDEN_RAM, type = rw,  define = yes, optional = yes;
     SHADOW_RAM2: load = SRPREPCHNK, run = HIDDEN_RAM, type = rw,  define = yes, optional = yes;

--- a/cfg/atarixl-overlay.cfg
+++ b/cfg/atarixl-overlay.cfg
@@ -65,7 +65,7 @@ SEGMENTS {
     SYSCHKTRL:   load = SYSCHKTRL,                     type = ro,                optional = yes;
 
     SRPREPHDR:   load = SRPREPHDR,                     type = ro;
-    LOWBSS:      load = SRPREPCHNK,                    type = bss, define = yes;  # shared btw. SRPREPCHNK and RAM, not zero initialized
+    LOWBSS:      load = SRPREPCHNK,                    type = bss, define = yes;  # shared btw. SRPREPCHNK and MAIN, not zero initialized
     SRPREP:      load = SRPREPCHNK,                    type = rw,  define = yes;
     SHADOW_RAM:  load = SRPREPCHNK, run = HIDDEN_RAM,  type = rw,  define = yes, optional = yes;
     SHADOW_RAM2: load = SRPREPCHNK, run = HIDDEN_RAM2, type = rw,  define = yes, optional = yes;

--- a/cfg/atarixl-xex.cfg
+++ b/cfg/atarixl-xex.cfg
@@ -48,7 +48,7 @@ SEGMENTS {
     EXTZP:       load = ZP,                            type = zp,                optional = yes;
 
     SYSCHK:      load = SYSCHKCHNK,                    type = rw,  define = yes, optional = yes;
-    LOWBSS:      load = SRPREPCHNK,                    type = bss, define = yes;  # shared btw. SRPREPCHNK and RAM, not zero initialized
+    LOWBSS:      load = SRPREPCHNK,                    type = bss, define = yes;  # shared btw. SRPREPCHNK and MAIN, not zero initialized
     SRPREP:      load = SRPREPCHNK,                    type = rw,  define = yes;
     SHADOW_RAM:  load = SRPREPCHNK, run = HIDDEN_RAM,  type = rw,  define = yes, optional = yes;
     SHADOW_RAM2: load = SRPREPCHNK, run = HIDDEN_RAM2, type = rw,  define = yes, optional = yes;

--- a/cfg/atarixl.cfg
+++ b/cfg/atarixl.cfg
@@ -52,7 +52,7 @@ SEGMENTS {
     SYSCHKTRL:   load = SYSCHKTRL,                     type = ro,                optional = yes;
 
     SRPREPHDR:   load = SRPREPHDR,                     type = ro;
-    LOWBSS:      load = SRPREPCHNK,                    type = bss, define = yes;  # shared btw. SRPREPCHNK and RAM, not zero initialized
+    LOWBSS:      load = SRPREPCHNK,                    type = bss, define = yes;  # shared btw. SRPREPCHNK and MAIN, not zero initialized
     SRPREP:      load = SRPREPCHNK,                    type = rw,  define = yes;
     SHADOW_RAM:  load = SRPREPCHNK, run = HIDDEN_RAM,  type = rw,  define = yes, optional = yes;
     SHADOW_RAM2: load = SRPREPCHNK, run = HIDDEN_RAM2, type = rw,  define = yes, optional = yes;


### PR DESCRIPTION
…4b83bd411736472e1c16fb1b0c0

adjust comments accordingly