### PR TITLE
Rebase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ jobs:
       - sudo apt-get update
       - sudo apt-get install linuxdoc-tools linuxdoc-tools-info binutils-mingw-w64-i686 gcc-mingw-w64-i686 sshpass
     script:
-      - make bin USER_CFLAGS=-Werror
-      - make lib QUIET=1
-      - make test QUIET=1
-      - make samples
+      - make -j2 bin USER_CFLAGS=-Werror
+      - make -j2 lib QUIET=1
+      - make -j2 test QUIET=1
+      - make -j2 samples
       - make -C src clean
-      - make bin USER_CFLAGS=-Werror CROSS_COMPILE=i686-w64-mingw32-
+      - make -j2 bin USER_CFLAGS=-Werror CROSS_COMPILE=i686-w64-mingw32-
       - make -C samples clean
-      - make doc zip
+      - make -j2 doc zip
     after_success:
       - make -f Makefile.travis
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Wiki](https://github.com/cc65/wiki/wiki)
 
-[![Build Status](https://api.travis-ci.org/cc65/cc65.svg?branch=master)](https://travis-ci.org/cc65/cc65/builds)
+[![Build Status](https://app.travis-ci.com/cc65/cc65.svg?branch=master)](https://app.travis-ci.com/cc65/cc65)
 
 cc65 is a complete cross development package for 65(C)02 systems, including
 a powerful macro assembler, a C compiler, linker, librarian and several

--- a/doc/apple2.sgml
+++ b/doc/apple2.sgml
@@ -428,8 +428,8 @@ The names in the parentheses denote the symbols to be used for static linking of
 
   <tag><tt/a2.ssc.ser (a2_ssc_ser)/</tag>
   Driver for the Apple&nbsp;II Super Serial Card. Supports up to 19200 baud,
-  hardware flow control (RTS/CTS) and interrupt driven receives. Note
-  that because of the peculiarities of the 6551 chip transmits are not
+  requires hardware flow control (RTS/CTS) and does interrupt driven receives.
+  Note that because of the peculiarities of the 6551 chip transmits are not
   interrupt driven, and the transceiver blocks if the receiver asserts
   flow control because of a full buffer.
 

--- a/doc/apple2enh.sgml
+++ b/doc/apple2enh.sgml
@@ -428,8 +428,8 @@ The names in the parentheses denote the symbols to be used for static linking of
 
   <tag><tt/a2e.ssc.ser (a2e_ssc_ser)/</tag>
   Driver for the Apple&nbsp;II Super Serial Card. Supports up to 19200 baud,
-  hardware flow control (RTS/CTS) and interrupt driven receives. Note
-  that because of the peculiarities of the 6551 chip transmits are not
+  requires hardware flow control (RTS/CTS) and does interrupt driven receives.
+  Note that because of the peculiarities of the 6551 chip transmits are not
   interrupt driven, and the transceiver blocks if the receiver asserts
   flow control because of a full buffer.
 

--- a/doc/atari.sgml
+++ b/doc/atari.sgml
@@ -675,9 +675,9 @@ The default callbacks definition (<tt/mouse_def_callbacks/) is an alias for the 
 
 <sect1>RS232 device drivers<p>
 
-Currently there is one RS232 driver.  It uses the R: device (therefore
-an R: driver needs to be installed) and was tested with the 850
-interface module.
+Currently there is one RS232 driver. It supports up to 9600 baud, requires hardware flow control
+(RTS/CTS) and uses the R: device (therefore an R: driver needs to be installed). It was tested
+with the 850 interface module.
 
 <table>
 <tabular ca="rr">

--- a/doc/atmos.sgml
+++ b/doc/atmos.sgml
@@ -176,10 +176,11 @@ No mouse drivers are currently available for the Atmos.
 
   <tag><tt/atmos-acia.ser (atmos_acia_ser)/</tag>
   Driver for the Telestrat integrated serial controller and the Atmos with a
-  serial add-on.
-  Note that, because of the peculiarities of the 6551 chip, together with the
-  use of the NMI, transmits are not interrupt driven; and, the transceiver
-  blocks if the receiver asserts flow control because of a full buffer.
+  serial add-on. Supports up to 19200 baud, requires hardware flow control
+  (RTS/CTS) and does interrupt driven receives. Note that, because of the
+  peculiarities of the 6551 chip, together with the use of the NMI, transmits
+  are not interrupt driven; and, the transceiver blocks if the receiver
+  asserts flow control because of a full buffer.
 
 </descrip><p>
 

--- a/doc/c128.sgml
+++ b/doc/c128.sgml
@@ -324,9 +324,9 @@ The default drivers, <tt/mouse_stddrv (mouse_static_stddrv)/, point to <tt/c128-
 <descrip>
 
   <tag><tt/c128-swlink.ser (c128_swlink_ser)/</tag>
-  Driver for the SwiftLink cartridge. Supports up to 38400 BPS, hardware flow
-  control (RTS/CTS), and interrupt-driven receives. Note that, because of the
-  peculiarities of the 6551 chip, together with the use of the NMI, transmits
+  Driver for the SwiftLink cartridge. Supports up to 38400 baud, requires hardware
+  flow control (RTS/CTS) and does interrupt driven receives. Note that, because of
+  the peculiarities of the 6551 chip, together with the use of the NMI, transmits
   are not interrupt driven; and, the transceiver blocks if the receiver asserts
   flow control because of a full buffer.
 

--- a/doc/c64.sgml
+++ b/doc/c64.sgml
@@ -410,9 +410,9 @@ The default drivers, <tt/mouse_stddrv (mouse_static_stddrv)/, point to <tt/c64-1
 <descrip>
 
   <tag><tt/c64-swlink.ser (c64_swlink_ser)/</tag>
-  Driver for the SwiftLink cartridge. Supports up to 38400 BPS, hardware flow
-  control (RTS/CTS), and interrupt-driven receives. Note that, because of the
-  peculiarities of the 6551 chip, together with the use of the NMI, transmits
+  Driver for the SwiftLink cartridge. Supports up to 38400 baud, requires hardware
+  flow control (RTS/CTS) and does interrupt driven receives. Note that, because of
+  the peculiarities of the 6551 chip, together with the use of the NMI, transmits
   are not interrupt driven; and, the transceiver blocks if the receiver asserts
   flow control because of a full buffer.
 

--- a/doc/cbm510.sgml
+++ b/doc/cbm510.sgml
@@ -231,10 +231,10 @@ The default drivers, <tt/mouse_stddrv (mouse_static_stddrv)/, point to <tt/cbm51
 
   <tag><tt/cbm510-std.ser (cbm510_std_ser)/</tag>
   Driver for the 6551 ACIA chip built into the Commodore 510. Supports up to
-  19200 BPS, hardware flow control (RTS/CTS), and interrupt-driven receives.
-  Note that, because of the peculiarities of the 6551 chip, transmits are not
-  interrupt driven; and, the transceiver blocks if the receiver asserts flow
-  control because of a full buffer.
+  19200 baud, requires hardware flow control (RTS/CTS) and does interrupt driven
+  receives. Note that, because of the peculiarities of the 6551 chip, transmits
+  are not interrupt driven; and, the transceiver blocks if the receiver asserts
+  flow control because of a full buffer.
 
 </descrip><p>
 

--- a/doc/cbm610.sgml
+++ b/doc/cbm610.sgml
@@ -212,10 +212,10 @@ No mouse drivers are currently available for the Commodore 610.
 
   <tag><tt/cbm610-std.ser (cbm610_std_ser)/</tag>
   Driver for the 6551 ACIA chip built into the Commodore 610. Supports up to
-  19200 BPS, hardware flow control (RTS/CTS), and interrupt-driven receives.
-  Note that, because of the peculiarities of the 6551 chip, transmits are not
-  interrupt driven; and, the transceiver blocks if the receiver asserts flow
-  control because of a full buffer.
+  19200 baud, requires hardware flow control (RTS/CTS) and does interrupt driven
+  receives. Note that, because of the peculiarities of the 6551 chip, transmits
+  are not interrupt driven; and, the transceiver blocks if the receiver asserts
+  flow control because of a full buffer.
 
 </descrip><p>
 

--- a/doc/funcref.sgml
+++ b/doc/funcref.sgml
@@ -5880,8 +5880,6 @@ void main (void)
 <tag/Declaration/<tt/void psg_silence (void);/
 <tag/Description/The function resets the Programmable Sound Generator,
 then sends $9F, $BF, $DF, $FF to the PSG.
-<tag/Notes/<itemize>
-</itemize>
 <tag/Availability/cc65
 <tag/See also/
 <ref id="psg_delay" name="psg_delay">,

--- a/doc/gamate.sgml
+++ b/doc/gamate.sgml
@@ -3,7 +3,7 @@
 <article>
 <title>Gamate System specific information for cc65
 <author>
-<url url="mailto:groepaz@gmx.net" name="Groepaz/Hitmen">
+<url url="mailto:groepaz@gmx.net" name="Groepaz">
 
 <abstract>
 An overview over the Gamate runtime system as it is implemented for the
@@ -117,14 +117,7 @@ following functions (and a few others):
 <sect>Other hints<p>
 
 <itemize>
-<item>The Gamate is emulated by MESS (<url url="http://www.mess.org/">),
-run like this: <tt>mess gamate -debug -window -skip_gameinfo -cart test.bin</tt>
-</itemize>
-
-some resources on the Gamate:
-
-<itemize>
-<item><url url="http://en.wikipedia.org/wiki/Gamate">
+<item>some resources on the Gamate: <url url="http://en.wikipedia.org/wiki/Gamate">
 </itemize>
 
 <sect>License<p>

--- a/doc/intro.sgml
+++ b/doc/intro.sgml
@@ -6,6 +6,7 @@
 <url url="mailto:uz@cc65.org" name="Ullrich von Bassewitz">,<newline>
 <url url="mailto:cbmnut@hushmail.com" name="CbmNut">,<newline>
 <url url="mailto:greg.king5@verizon.net" name="Greg King">,<newline>
+<url url="mailto:groepaz@gmx.net" name="Groepaz">,<newline>
 <url url="mailto:stephan.muehlstrasser@web.de" name="Stephan M&uuml;hlstrasser">
 
 <abstract>
@@ -458,12 +459,8 @@ Substitute the name of a Commodore computer for that <tt/&lt;sys&gt;/:
 Start the desired version of the emulator (CBM610 programs run on
 the CBM II &lsqb;<tt/xcbm2/&rsqb; emulator).
 
-In the Windows versions of VICE, choose <bf>File&gt;Autoboot disk/tape
-image...</bf>, choose your executable, and click <bf/OK/.
-
-In the Unix versions, hold down the mouse's first button. Move the pointer to
-<bf>Smart-attach disk/tape...</bf>, and release the button. Choose your
-executable, and click <bf/Autostart/.
+Choose <bf>File&gt;Autostart disk/tape image...</bf>, choose your executable, 
+and click <bf/OK/.
 
 The file has a 14-byte header which corresponds to a PRG-format BASIC program,
 consisting of a single line, similar to this:
@@ -497,6 +494,29 @@ RUN "HELLO"
 
 The output will appear on a separate line, and you will be returned to a BASIC
 prompt.
+
+
+<sect1>Gamate<p>
+
+Before you can run the cartridge image produced by the linker, the binary has to
+be patched using the <bf/gamate-fixcart/ tool that is included in the cc65
+package in the util/gamata directory.
+
+<tscreen><verb>
+gamate-fixcart <image.bin>
+</verb></tscreen>
+
+<sect2>MESS<p>
+Available at <url
+url="https://www.mamedev.org">:
+
+MESS (Multiple Emulator Super System) is a multi system emulator that emulates
+various cc65 targets. It once started as a MAME fork, but was marged into MAME
+again at some point.
+
+<tscreen><verb>
+mess gamate -debug -window -skip_gameinfo -cart <image.bin>
+</verb></tscreen>
 
 
 <sect1>GEOS<p>
@@ -535,17 +555,8 @@ feature on.
 </quote>
 
 <quote>
-VICE even has different ways that depend on which operating system is running
-the emulator.
-<itemize>
-<item>In Windows, you must click on <bf/Options/ (in an always visible menu).
-      Then, you must click on <bf/True drive emulation/.
-<item>In Unix, you must <em/hold down/ the second button on your mouse.  Move
-      the pointer down to <bf/Drive settings/.  Then, move the pointer over to
-      <bf/Enable true drive emulation/.  (If there is a check-mark in front of
-      those words, that feature already is turned on -- then, move the pointer
-      off of that menu.) Release the mouse button.
-</itemize>
+In VICE, got to <bf/Settings/ -> <bf/Settings/, then <bf/Peripherial devices/ ->
+<bf/Drive/. Then, you must enable the <bf/True drive emulation/ checkbox.
 </quote>
 
 Find the <bf/CONVERT/ program on the boot disk &lsqb;tap the 6-key; then, you
@@ -571,6 +582,29 @@ directory notePad.  Look at the eight file-positions on each page until you see
 
 The output is shown in a GEOS dialog box; click <bf/OK/ when you have finished
 reading it.
+
+Alternatively you can use the <bf/c1541/ program that comes with VICE to write the
+file to a disk image directly in GEOS format, so it can be used in GEOS directly
+without having to use the <bf/CONVERT/ program.
+
+<tscreen><verb>
+c1541 -attach geos.d64 -geoswrite hello1
+</verb></tscreen>
+
+
+<sect1>Nintendo Entertainment System<p>
+
+<sect2>Mednafen (NES)<p>
+Available at <url
+url="https://mednafen.github.io/releases/">:
+
+Mednafen is a multi system emulator that emulates a couple of the supported
+targets of cc65: Apple II/II+, Atari Lynx, Nintendo Entertainment System and
+PC Engine/TurboGrafx 16.
+
+<tscreen><verb>
+mednafen -force_module nes <image.bin>
+</verb></tscreen>
 
 
 <sect1>Ohio Scientific Challenger 1P<p>
@@ -692,6 +726,32 @@ Press <RETURN>.
 </verb></tscreen>
 
 After hitting the RETURN key, you should see the boot prompt again.
+
+
+<sect1>PC Engine/TurboGrafx 16<p>
+
+For the cartridge image produced by the linker to work in emulators and on real
+hardware, its content must be rearranged so the first 8k block becomes the last
+8k block in the image.
+
+For example, for a 32k image this can be done using <bf/dd/ as follows:
+
+<tscreen><verb>
+dd if=infile.bin bs=8K skip=3 > outfile.pce
+dd if=infile.bin bs=8K count=3 >> outfile.pce
+</verb></tscreen>
+
+<sect2>Mednafen<p>
+Available at <url
+url="https://mednafen.github.io/releases/">:
+
+Mednafen is a multi system emulator that emulates a couple of the supported
+targets of cc65: Apple II/II+, Atari Lynx, Nintendo Entertainment System and
+PC Engine/TurboGrafx 16.
+
+<tscreen><verb>
+mednafen -force_module pce <image.pce>
+</verb></tscreen>
 
 
 <sect1>Contributions wanted<p>

--- a/doc/pce.sgml
+++ b/doc/pce.sgml
@@ -2,7 +2,7 @@
 
 <article>
 <title>PC-Engine (TurboGrafx 16) System-specific information for cc65
-<author><url url="mailto:groepaz@gmx.net" name="Groepaz/Hitmen">,<newline>
+<author><url url="mailto:groepaz@gmx.net" name="Groepaz">,<newline>
 <url url="mailto:greg.king5@verizon.net" name="Greg King">
 
 <abstract>
@@ -205,11 +205,6 @@ following functions (and a few others):
 
 
 <sect>Other hints<p>
-
-<itemize>
-<item><url url="https://mednafen.github.io/" name= "Mednafen"> is a good
-emulator to use for the PC-Engine.
-</itemize>
 
 Some useful resources on PCE coding:
 

--- a/doc/plus4.sgml
+++ b/doc/plus4.sgml
@@ -195,10 +195,10 @@ No mouse drivers are currently available for the Plus/4.
 
   <tag><tt/plus4-stdser.ser (plus4_stdser_ser)/</tag>
   Driver for the 6551 ACIA chip built into the Plus/4. Supports up to 19200
-  baud, hardware flow control (RTS/CTS) and interrupt driven receives. Note
-  that because of the peculiarities of the 6551 chip transmits are not
-  interrupt driven, and the transceiver blocks if the receiver asserts flow
-  control because of a full buffer.
+  baud, requires hardware flow control (RTS/CTS) and does interrupt driven
+  receives. Note that because of the peculiarities of the 6551 chip transmits
+  are not interrupt driven, and the transceiver blocks if the receiver asserts
+  flow control because of a full buffer.
 
   You need an adapter to use the builtin port, since the output levels
   available at the user port don't follow the RS232 standard.

--- a/src/cc65/coptstop.c
+++ b/src/cc65/coptstop.c
@@ -1113,9 +1113,9 @@ static unsigned Opt_a_toscmpbool (StackOpData* D, const char* BoolTransformer)
 
     D->IP = D->OpIndex + 1;
 
-    if (!D->RhsMultiChg &&
-        (D->Rhs.A.LoadEntry->Flags & CEF_DONT_REMOVE) == 0 &&
-        (D->Rhs.A.Flags & LI_DIRECT) != 0) {
+    if (!D->RhsMultiChg                     &&
+        (D->Rhs.A.Flags & LI_DIRECT) != 0   &&
+        (D->Rhs.A.LoadEntry->Flags & CEF_DONT_REMOVE) == 0) {
 
         /* cmp */
         AddOpLow (D, OP65_CMP, &D->Rhs);

--- a/targettest/cbm/Makefile
+++ b/targettest/cbm/Makefile
@@ -30,10 +30,13 @@ else
   LD := $(if $(wildcard ../../../bin/ld65*),../../../bin/ld65,ld65)
 endif
 
-all: petscii.prg
+all: petscii.prg cbmdir-test.prg
 
 petscii.prg: petscii.c
 	$(CL) -t $(SYS) -O -o petscii.prg petscii.c
 
+cbmdir-test.prg: cbmdir-test.c
+	$(CL) -t $(SYS) -Oris -o $@ $<
+
 clean:
-	@$(DEL) petscii.prg 2>$(NULLDEV)
+	@$(DEL) petscii.prg cbmdir-test.prg 2>$(NULLDEV)

--- a/targettest/cbm/cbmdir-test.c
+++ b/targettest/cbm/cbmdir-test.c
@@ -1,0 +1,119 @@
+/*
+** Tests the CBM-specific directory functions.
+**
+** 2021-08-12, Greg King
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <conio.h>
+#include <cbm.h>
+
+
+/* device number */
+#define UNIT 8
+
+/* directory patterm */
+static const char name[] = "$";
+
+
+static const char* const type[] = {
+    "DEL",
+    "CBM",
+    "DIR",
+    "LNK",
+    "???",
+    "Directory header",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "SEQ",
+    "PRG",
+    "USR",
+    "REL",
+    "VRP"
+};
+
+static const char* const access[] = {
+    "unknown",
+    "read-only",
+    "write-only",
+    "read/write"
+};
+
+static const char* const error[] = {
+    "",
+    "couldn't read it",
+    "",
+    "couldn't find start of file-name",
+    "couldn't find end of file-name",
+    "couldn't read file-type",
+    "premature end of file"
+};
+
+
+int main(void)
+{
+    unsigned char go = 0;
+    unsigned char rc;
+    struct cbm_dirent E;
+
+    /* Explain use, and wait for a key. */
+    printf ("use the following keys:\n"
+            "  g -> go ahead without stopping\n"
+            "  q -> quit directory lister\n"
+            "tap any key to start ...\n\n");
+    cgetc ();
+
+    /* Open the directory. */
+    if (cbm_opendir (1, UNIT, name) != 0) {
+        printf("error opening %s:\n %s\n", name, _stroserror (_oserror));
+        return 1;
+    }
+
+    /* Output the directory. */
+    printf("contents of \"%s\":\n", name);
+    while ((rc = cbm_readdir (1, &E)) != 2) {
+        if (rc != 0) {
+            goto oops;
+        }
+
+        printf (" name[]: \"%s\"\n", E.name);
+        printf (" size  :%6u\n",     E.size);
+        printf (" type  : %s\n",     type[E.type]);
+        printf (" access: %s\n",     access[E.access > 3 ? 0 : E.access]);
+        printf ("----\n");
+
+        if (!go) {
+            switch (cgetc ()) {
+              case 'q':
+                goto done;
+
+              case 'g':
+                go = 1;
+            }
+        }
+    }
+
+    printf (" size  :%6u free.\n", E.size);
+
+done:
+    /* Close the directory. */
+    cbm_closedir (1);
+    return 0;
+
+oops:
+    if (rc <= 6) {
+        printf ("\ndirectory error:\n %s.\n", error[rc]);
+    }
+    cbm_closedir (1);
+    return 1;
+}

--- a/targettest/pce/Makefile
+++ b/targettest/pce/Makefile
@@ -42,14 +42,15 @@ else
 COUNT := 1
 endif
 
-all: conio.pce
+all: conio.bin
+
+%.bin: %.c
+	$(CL) -t pce $< -Wl -D__CARTSIZE__=${CARTSIZE} -m $*.map -o $@
+	@echo "use 'make conio.pce' to produce a .pce file using dd"
 
 %.pce: %.bin
 	dd if=$< bs=8K skip=${COUNT} > $@
 	dd if=$< bs=8K count=${COUNT} >> $@
-
-%.bin: %.c
-	$(CL) -t pce $< -Wl -D__CARTSIZE__=${CARTSIZE} -m $*.map -o $@
 
 clean:
 	@$(DEL) conio.o conio.??? 2>$(NULLDEV)

--- a/test/val/bug1552.c
+++ b/test/val/bug1552.c
@@ -1,0 +1,42 @@
+
+/*
+    bug #1552 - crash in fuzix xec.c
+
+    cc65 -t none -O bug1552.c
+*/
+
+#include <stdio.h>
+
+typedef struct trenod *TREPTR;
+typedef struct whnod *WHPTR;
+
+struct trenod {
+    int tretyp;
+};
+
+struct whnod {
+    int whtyp;
+    TREPTR whtre;
+};
+
+int execute(TREPTR argt, int execflg, int *pf1, int *pf2)
+{
+    register TREPTR t;
+    int type;
+    switch (type) 
+    {
+        case 6:
+        {
+            while ((execute(((WHPTR) t)->whtre, 0, NULL, NULL) == 0) == (type == 5)) {
+
+            }
+            break;
+        }
+    }
+    return 0;
+}
+
+int main(void)
+{
+    return execute((TREPTR)42, 2, (int *)3, (int *)4);
+}

--- a/test/val/bug1562.c
+++ b/test/val/bug1562.c
@@ -1,0 +1,30 @@
+
+/* bug 1562: cc65 generates incorrect code for logical expression with -O */
+
+#include <stdio.h>
+#include <string.h>
+
+int failures = 0;
+
+char input[256];
+
+#define DEBUGTRUE(x) printf("%s=%d\n", #x, (x)); failures += (x) ? 0 : 1
+
+#define DEBUGFALSE(x) printf("%s=%d\n", #x, (x)); failures += (x) ? 1 : 0
+
+int main(void) {
+    char* r;
+    strcpy(input, "\"XYZ\"");
+    r = input+4;
+    DEBUGFALSE(*r != '"');       // = false
+    DEBUGTRUE(*r == '"');       // = true
+    DEBUGFALSE(*(r+1) == '"');   // = false
+    // Next answer should be false because
+    // (false || true && false) is false, but it is true with -O.
+    DEBUGFALSE(*r != '"' || *r == '"' && *(r+1) == '"');
+    // Adding parens fixes it even with -O.
+    DEBUGFALSE(*r != '"' || (*r == '"' && *(r+1) == '"'));
+
+    printf("failures: %d\n", failures);
+    return failures;
+}


### PR DESCRIPTION
The notes section of psg_silence (Creativision funcref) contained an
empty Notes section, consisting of an empty <itemize> only.

Newer sgmltools fail on this, as they insist on having an <item>
element, or they fail compilation:

[  225s] Processing file ../doc/funcref.sgml
[  225s] onsgmls:/tmp/linuxdoc-tools.NfxbjODQbW/sgmltmp.funcref.01.precmdout:5884:9:E:end tag for "ITEMIZE" which is not finished

Fixed this by removing the (empty) Notes section altogether.